### PR TITLE
feat: Implement priority-based subscription plan change

### DIFF
--- a/app/Jobs/ProcessRazorpayWebhook.php
+++ b/app/Jobs/ProcessRazorpayWebhook.php
@@ -10,6 +10,7 @@ use App\Models\Subscription;
 use App\Models\WebhookLog;
 use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
+use Razorpay\Api\Api as RazorpayApi;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
@@ -44,8 +45,7 @@ class ProcessRazorpayWebhook implements ShouldQueue
     public function handle()
     {
         $subscriptionPayload = $this->payload['subscription']['entity'];
-        
-        // Eager-load relationships for use in emails
+
         $subscription = Subscription::with(['user', 'plan'])
             ->where('razorpay_subscription_id', $subscriptionPayload['id'])
             ->first();
@@ -54,12 +54,20 @@ class ProcessRazorpayWebhook implements ShouldQueue
             Log::warning('ProcessRazorpayWebhook: Subscription not found for Razorpay ID: ' . $subscriptionPayload['id']);
             return;
         }
-        
+
         $log = WebhookLog::where('razorpay_subscription_id', $subscriptionPayload['id'])
             ->where('event_type', $this->eventName)
             ->where('status', 'received')
             ->latest()
             ->first();
+
+        // Check for plan change flow
+        $api = new RazorpayApi(env('RAZORPAY_KEY'), env('RAZORPAY_SECRET'));
+        $razorpaySubscription = $api->subscription->fetch($subscription->razorpay_subscription_id);
+
+        if (isset($razorpaySubscription->notes['flow']) && $razorpaySubscription->notes['flow'] === 'plan_change') {
+            $this->handlePlanChange($subscription, $razorpaySubscription->notes);
+        }
 
         switch ($this->eventName) {
             case 'subscription.activated':
@@ -70,6 +78,7 @@ class ProcessRazorpayWebhook implements ShouldQueue
                 break;
 
             case 'subscription.updated':
+                // This case might still be needed for other types of updates
                 $newPlan = Plan::where('razorpay_plan_id', $subscriptionPayload['plan_id'])->first();
                 if ($newPlan) {
                     $subscription->plan_id = $newPlan->id;
@@ -78,9 +87,10 @@ class ProcessRazorpayWebhook implements ShouldQueue
                 break;
 
             case 'subscription.charged':
+                $subscription->status = 'active'; // Ensure status is active on charge
                 $newEndDate = $subscription->ends_at ? Carbon::parse($subscription->ends_at) : Carbon::now();
-                $subscription->ends_at = ($subscription->plan->billing_interval === 'year') 
-                    ? $newEndDate->addYear() 
+                $subscription->ends_at = ($subscription->plan->billing_interval === 'year')
+                    ? $newEndDate->addYear()
                     : $newEndDate->addMonth();
                 $subscription->save();
                 Mail::to($subscription->user)->send(new SubscriptionCharged($subscription));
@@ -97,14 +107,55 @@ class ProcessRazorpayWebhook implements ShouldQueue
                 $subscription->status = 'on_hold';
                 $subscription->save();
                 break;
-            
+
             default:
                 if ($log) $log->update(['status' => 'unhandled_event']);
                 return;
         }
-        
+
         if ($log) {
             $log->update(['status' => 'processed', 'processed_at' => Carbon::now()]);
+        }
+    }
+
+    /**
+     * Handle the logic for plan changes.
+     *
+     * @param \App\Models\Subscription $newSubscription
+     * @param object $notes
+     * @return void
+     */
+    protected function handlePlanChange(Subscription $newSubscription, $notes)
+    {
+        $oldSubscription = Subscription::where('razorpay_subscription_id', $notes['old_subscription_id'])->with('plan')->first();
+
+        if (!$oldSubscription) {
+            Log::error('Plan Change: Old subscription not found for Razorpay ID: ' . $notes['old_subscription_id']);
+            return;
+        }
+
+        $newPlan = $newSubscription->plan;
+        $oldPlan = $oldSubscription->plan;
+
+        $api = new RazorpayApi(env('RAZORPAY_KEY'), env('RAZORPAY_SECRET'));
+
+        // Upgrade: Cancel old subscription immediately
+        if ($newPlan->priority > $oldPlan->priority) {
+            try {
+                $api->subscription->fetch($oldSubscription->razorpay_subscription_id)->cancel(['cancel_at_cycle_end' => false]);
+                Log::info('Plan Change (Upgrade): Cancelled old subscription immediately: ' . $oldSubscription->razorpay_subscription_id);
+            } catch (\Exception $e) {
+                Log::error('Plan Change (Upgrade): Failed to cancel old subscription: ' . $e->getMessage());
+            }
+        }
+        // Downgrade: Cancel old subscription at the end of its cycle
+        else {
+            try {
+                $api->subscription->fetch($oldSubscription->razorpay_subscription_id)->cancel(['cancel_at_cycle_end' => true]);
+                Log::info('Plan Change (Downgrade): Scheduled cancellation for old subscription: ' . $oldSubscription->razorpay_subscription_id);
+            } catch (\Exception $e) {
+                Log::error('Plan Change (Downgrade): Failed to schedule cancellation for old subscription: ' . $e->getMessage());
+            }
         }
     }
 }

--- a/database/migrations/2025_09_15_063934_add_priority_to_plans_table.php
+++ b/database/migrations/2025_09_15_063934_add_priority_to_plans_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('plans', function (Blueprint $table) {
+            $table->integer('priority')->default(0)->after('description');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('plans', function (Blueprint $table) {
+            $table->dropColumn('priority');
+        });
+    }
+};


### PR DESCRIPTION
Reworks the subscription plan change functionality to use a "create and cancel" strategy instead of updating the existing subscription.

- Adds a `priority` field to the `plans` table to differentiate between high-value and low-value plans.
- Modifies `SubscriptionController@update` to create a new Razorpay subscription when a user changes their plan.
  - For upgrades (lower to higher priority), the new plan starts immediately.
  - For downgrades (higher to lower priority), the new plan is scheduled to start at the end of the current billing cycle.
- Enhances the `ProcessRazorpayWebhook` job to handle the cancellation of the old subscription upon successful payment of the new one.
  - Upgrades trigger an immediate cancellation of the old subscription.
  - Downgrades trigger a cancellation at the end of the billing cycle.